### PR TITLE
Improve qualification flow and page layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,25 +43,20 @@ body {
 }
 
 .hero {
-  background: url("https://images.unsplash.com/photo-1605478900747-37c2d0ef6e1a?auto=format&fit=crop&w=1400&q=80")
-    center/cover no-repeat;
-  color: #fff;
+  background-image: url("https://images.unsplash.com/photo-1509395176047-4a66953fd231?auto=format&fit=crop&w=1400&q=80");
+  background-size: cover;
+  background-position: center;
   text-align: center;
   color: #fff;
-}
-
-.hero-image {
-  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   height: 60vh;
-  object-fit: cover;
-  display: block;
+  padding: 0 1rem;
 }
 
 .hero-content {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  max-width: 600px;
 }
 
 .hero h1 {
@@ -116,6 +111,35 @@ body {
 
 .qualify-form legend {
   font-weight: 600;
+}
+
+.qualify-form .form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.qualify-form fieldset.basic-info {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.qualify-form fieldset.upgrades .checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.5rem;
+}
+
+.qualify-form fieldset.upgrades .checkbox-grid label {
+  display: flex;
+  align-items: center;
+}
+
+.qualify-form .sub-group {
+  border: none;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
 }
 
 .contact-form input,

--- a/index.html
+++ b/index.html
@@ -38,11 +38,6 @@
     </header>
 
     <section class="hero">
-      <img
-        src="https://images.unsplash.com/photo-1605478900747-37c2d0ef6e1a?auto=format&fit=crop&w=1400&q=80"
-        alt="Sunrise over Greensboro rooftops with solar panels."
-        class="hero-image"
-      />
       <div class="hero-content">
         <h1>Your Roof. Your Rules.</h1>
         <p>
@@ -60,25 +55,6 @@
         energy means freedom, ownership, and independence. Take back your
         money—take back your power.
       </p>
-      <img
-        src="https://images.unsplash.com/photo-1562207520-19c0ebd8264f?auto=format&fit=crop&w=1200&q=80"
-        alt="Greensboro neighborhood rooftops with solar panels installed."
-      />
-      <a href="qualify.html" class="cta">Break Free From Duke</a>
-    </section>
-
-    <section class="info-section" id="why-now">
-      <h2>Why Now? Take Back Your Energy</h2>
-      <p>
-        Every month, Greensboro homeowners send money to a single monopoly. Duke
-        Energy controls how much you pay, and they keep raising your bill. Solar
-        energy means freedom, ownership, and independence. Take back your
-        money—take back your power.
-      </p>
-      <img
-        src="https://images.unsplash.com/photo-1562207520-19c0ebd8264f?auto=format&fit=crop&w=1200&q=80"
-        alt="Greensboro neighborhood rooftops with solar panels installed."
-      />
       <a href="qualify.html" class="cta">Break Free From Duke</a>
     </section>
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,20 +1,42 @@
-document.addEventListener("DOMContentLoaded", () => {
-  const form = document.querySelector(".contact-form");
-  if (form) {
-    form.addEventListener("submit", (e) => {
-      e.preventDefault();
-      alert("Thanks for reaching out! We will contact you soon.");
-      form.reset();
-    });
-  }
+const form = document.querySelector(".contact-form");
+if (form) {
+  form.addEventListener("submit", (e) => {
+    e.preventDefault();
+    alert("Thanks for reaching out! We will contact you soon.");
+    form.reset();
+  });
+}
 
-  const hamburger = document.querySelector(".hamburger");
-  const navLinks = document.querySelector(".nav-links");
-  if (hamburger && navLinks) {
-    hamburger.addEventListener("click", () => {
-      const expanded = hamburger.getAttribute("aria-expanded") === "true";
-      hamburger.setAttribute("aria-expanded", String(!expanded));
-      navLinks.classList.toggle("active");
-    });
-  }
-});
+const hamburger = document.querySelector(".hamburger");
+const navLinks = document.querySelector(".nav-links");
+if (hamburger && navLinks) {
+  hamburger.addEventListener("click", () => {
+    const expanded = hamburger.getAttribute("aria-expanded") === "true";
+    hamburger.setAttribute("aria-expanded", String(!expanded));
+    navLinks.classList.toggle("active");
+  });
+}
+
+const estimator = document.querySelector(".estimator-form");
+if (estimator) {
+  estimator.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const bill = parseFloat(document.getElementById("bill").value);
+    if (!isNaN(bill)) {
+      const yearly = bill * 12 * 0.25;
+      const result = document.getElementById("savings-result");
+      if (result) {
+        result.textContent = `Estimated first-year savings: $${yearly.toFixed(0)}`;
+      }
+    }
+  });
+}
+
+const qualify = document.querySelector(".qualify-form");
+if (qualify) {
+  qualify.addEventListener("submit", (e) => {
+    e.preventDefault();
+    alert("Thanks! We'll review your info and follow up soon.");
+    qualify.reset();
+  });
+}

--- a/qualify.html
+++ b/qualify.html
@@ -40,7 +40,7 @@
     <main class="content">
       <section class="savings-estimator">
         <h2>Instant Solar Savings Estimator</h2>
-        <form class="estimator-form" action="#" method="post">
+        <form class="estimator-form" action="javascript:void(0)" method="post">
           <label for="bill">Average monthly electric bill (required)</label>
           <input type="number" id="bill" name="bill" required />
 
@@ -57,6 +57,7 @@
 
           <button type="submit">Calculate My Savings</button>
         </form>
+        <p id="savings-result"></p>
         <p>We respect your privacy. No spam. Just savings.</p>
       </section>
 
@@ -65,51 +66,65 @@
         The Greensboro Net Metering Program helps homeowners save more by
         feeding extra solar power back to the grid.
       </p>
-      <form class="qualify-form" action="#" method="post">
-        <fieldset>
+      <form class="qualify-form" action="javascript:void(0)" method="post">
+        <fieldset class="basic-info">
           <legend>Basic Information</legend>
 
-          <label for="homeowner">Are you a homeowner?</label>
-          <select id="homeowner" name="homeowner" required>
-            <option value="">Select</option>
-            <option>Yes</option>
-            <option>No</option>
-          </select>
+          <div class="form-group">
+            <label for="homeowner">Are you a homeowner?</label>
+            <select id="homeowner" name="homeowner" required>
+              <option value="">Select</option>
+              <option>Yes</option>
+              <option>No</option>
+            </select>
+          </div>
 
-          <label for="taxes">Do you file federal taxes?</label>
-          <select id="taxes" name="taxes" required>
-            <option value="">Select</option>
-            <option>Yes</option>
-            <option>No</option>
-          </select>
+          <div class="form-group">
+            <label for="taxes">Do you file federal taxes?</label>
+            <select id="taxes" name="taxes" required>
+              <option value="">Select</option>
+              <option>Yes</option>
+              <option>No</option>
+            </select>
+          </div>
 
-          <label for="credit">Is your credit score above 600?</label>
-          <select id="credit" name="credit" required>
-            <option value="">Select</option>
-            <option>Yes</option>
-            <option>No</option>
-          </select>
+          <div class="form-group">
+            <label for="credit">Is your credit score above 600?</label>
+            <select id="credit" name="credit" required>
+              <option value="">Select</option>
+              <option>Yes</option>
+              <option>No</option>
+            </select>
+          </div>
 
-          <label for="roof">What type of roof do you have?</label>
-          <select id="roof" name="roof" required>
-            <option value="">Select</option>
-            <option>Slatted</option>
-            <option>Panels</option>
-            <option>Other</option>
-          </select>
+          <div class="form-group">
+            <label for="roof">What type of roof do you have?</label>
+            <select id="roof" name="roof" required>
+              <option value="">Select</option>
+              <option>Slatted</option>
+              <option>Panels</option>
+              <option>Other</option>
+            </select>
+          </div>
 
-          <label for="billname">Whose name is on the electric bill?</label>
-          <input id="billname" name="billname" type="text" required />
+          <div class="form-group">
+            <label for="billname">Whose name is on the electric bill?</label>
+            <input id="billname" name="billname" type="text" required />
+          </div>
 
-          <label for="usage">12-month usage statement (kWh)</label>
-          <input id="usage" name="usage" type="text" required />
+          <div class="form-group">
+            <label for="usage">12-month usage statement (kWh)</label>
+            <input id="usage" name="usage" type="text" required />
+          </div>
 
-          <label for="decision">Are all decision makers present?</label>
-          <select id="decision" name="decision" required>
-            <option value="">Select</option>
-            <option>Yes</option>
-            <option>No</option>
-          </select>
+          <div class="form-group">
+            <label for="decision">Are all decision makers present?</label>
+            <select id="decision" name="decision" required>
+              <option value="">Select</option>
+              <option>Yes</option>
+              <option>No</option>
+            </select>
+          </div>
 
           <fieldset class="sub-group">
             <legend>Do you need roof or tree removal?</legend>
@@ -124,66 +139,68 @@
           </fieldset>
         </fieldset>
 
-        <fieldset>
+        <fieldset class="upgrades">
           <legend>Energy-Efficient Upgrades in the Last 12 Months</legend>
-          <label
-            ><input type="checkbox" name="upgrades" value="insulation" />
-            Insulation</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="windows" />
-            Windows</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="water heater" />
-            Water Heater</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="HVAC" /> HVAC</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="heat pump" /> Heat
-            Pump</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="pool" /> Pool</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="pool pump" /> Pool
-            Pump</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="smart thermostat" />
-            Smart Thermostat</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="washer" />
-            Washer</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="dryer" />
-            Dryer</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="fridge" />
-            Fridge</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="freezer" />
-            Freezer</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="led lights" /> LED
-            Lights</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="doors" />
-            Doors</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="other" />
-            Other</label
-          >
+          <div class="checkbox-grid">
+            <label
+              ><input type="checkbox" name="upgrades" value="insulation" />
+              Insulation</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="windows" />
+              Windows</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="water heater" />
+              Water Heater</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="HVAC" /> HVAC</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="heat pump" /> Heat
+              Pump</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="pool" /> Pool</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="pool pump" /> Pool
+              Pump</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="smart thermostat" />
+              Smart Thermostat</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="washer" />
+              Washer</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="dryer" />
+              Dryer</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="fridge" />
+              Fridge</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="freezer" />
+              Freezer</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="led lights" /> LED
+              Lights</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="doors" />
+              Doors</label
+            >
+            <label
+              ><input type="checkbox" name="upgrades" value="other" />
+              Other</label
+            >
+          </div>
         </fieldset>
 
         <button type="submit">Submit</button>


### PR DESCRIPTION
## Summary
- Move hero image behind "Your Roof. Your Rules." and remove stray photo from "Why Now?"
- Keep savings estimator and qualification forms client-side to avoid 405 errors
- Simplify client script by running listeners at load time

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914c95a338832b87f2bb38d523b01d