### PR TITLE
Add thank-you page and refine qualification funnel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,25 +43,22 @@ body {
 }
 
 .hero {
-  background: url("https://images.unsplash.com/photo-1605478900747-37c2d0ef6e1a?auto=format&fit=crop&w=1400&q=80")
-    center/cover no-repeat;
-  color: #fff;
   text-align: center;
   color: #fff;
-}
-
-.hero-image {
-  width: 100%;
-  height: 60vh;
-  object-fit: cover;
-  display: block;
+  position: relative;
+  min-height: 60vh;
+  background: url("https://images.unsplash.com/photo-1556906781-9cd24e83345e?auto=format&fit=crop&w=1400&q=80")
+    center/cover no-repeat;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .hero-content {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  padding: 0 1rem;
+  max-width: 600px;
+  text-align: center;
+  margin: 0 auto;
 }
 
 .hero h1 {
@@ -101,40 +98,66 @@ body {
   padding: 2rem;
 }
 
-.contact-form,
-.qualify-form {
+.contact-form {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   max-width: 400px;
 }
 
-.qualify-form fieldset {
-  border: 1px solid #ccc;
-  padding: 1rem;
-}
-
-.qualify-form legend {
-  font-weight: 600;
-}
-
 .contact-form input,
-.contact-form textarea,
-.qualify-form input,
-.qualify-form select {
+.contact-form textarea {
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
 }
 
-.contact-form button,
-.qualify-form button {
+.contact-form button {
   background: #1e88e5;
   color: #fff;
   padding: 0.5rem 1rem;
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+
+.qualify-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+  justify-items: center;
+}
+
+.prequal-quiz {
+  background: #e3f2fd;
+  padding: 2rem;
+  border-radius: 8px;
+  text-align: center;
+  max-width: 500px;
+}
+
+.step {
+  display: none;
+}
+
+.step.active {
+  display: block;
+}
+
+.step label {
+  display: block;
+  margin-top: 1rem;
+}
+
+.step button {
+  background: #1e88e5;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 1rem;
 }
 
 .estimator-form {
@@ -151,7 +174,6 @@ body {
   border-radius: 8px;
   text-align: center;
   max-width: 500px;
-  margin: 0 auto 2rem;
 }
 
 .estimator-form label {

--- a/index.html
+++ b/index.html
@@ -38,11 +38,6 @@
     </header>
 
     <section class="hero">
-      <img
-        src="https://images.unsplash.com/photo-1605478900747-37c2d0ef6e1a?auto=format&fit=crop&w=1400&q=80"
-        alt="Sunrise over Greensboro rooftops with solar panels."
-        class="hero-image"
-      />
       <div class="hero-content">
         <h1>Your Roof. Your Rules.</h1>
         <p>
@@ -60,25 +55,6 @@
         energy means freedom, ownership, and independence. Take back your
         money—take back your power.
       </p>
-      <img
-        src="https://images.unsplash.com/photo-1562207520-19c0ebd8264f?auto=format&fit=crop&w=1200&q=80"
-        alt="Greensboro neighborhood rooftops with solar panels installed."
-      />
-      <a href="qualify.html" class="cta">Break Free From Duke</a>
-    </section>
-
-    <section class="info-section" id="why-now">
-      <h2>Why Now? Take Back Your Energy</h2>
-      <p>
-        Every month, Greensboro homeowners send money to a single monopoly. Duke
-        Energy controls how much you pay, and they keep raising your bill. Solar
-        energy means freedom, ownership, and independence. Take back your
-        money—take back your power.
-      </p>
-      <img
-        src="https://images.unsplash.com/photo-1562207520-19c0ebd8264f?auto=format&fit=crop&w=1200&q=80"
-        alt="Greensboro neighborhood rooftops with solar panels installed."
-      />
       <a href="qualify.html" class="cta">Break Free From Duke</a>
     </section>
 

--- a/js/main.js
+++ b/js/main.js
@@ -17,4 +17,47 @@ document.addEventListener("DOMContentLoaded", () => {
       navLinks.classList.toggle("active");
     });
   }
+
+  const estimator = document.querySelector(".estimator-form");
+  if (estimator) {
+    estimator.addEventListener("submit", (e) => {
+      e.preventDefault();
+      const bill = parseFloat(document.getElementById("bill").value);
+      const zip = document.getElementById("zip").value.trim();
+      if (!isNaN(bill) && zip) {
+        const monthly = bill * 0.25;
+        const yearly = monthly * 12;
+        const result = document.getElementById("savings-result");
+        if (result) {
+          result.textContent = `Homes in ${zip} could save about $${monthly.toFixed(0)} per month (~$${yearly.toFixed(0)} per year).`;
+        }
+      }
+    });
+  }
+
+  const quiz = document.getElementById("quiz-form");
+  if (quiz) {
+    const steps = quiz.querySelectorAll(".step");
+    let current = 0;
+
+    const showStep = (index) => {
+      steps[current].classList.remove("active");
+      current = index;
+      steps[current].classList.add("active");
+    };
+
+    quiz.querySelectorAll(".next").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const input = steps[current].querySelector("input, select");
+        if (!input || input.reportValidity()) {
+          showStep(Math.min(current + 1, steps.length - 1));
+        }
+      });
+    });
+
+    quiz.addEventListener("submit", (e) => {
+      e.preventDefault();
+      window.location.href = "thankyou.html";
+    });
+  }
 });

--- a/qualify.html
+++ b/qualify.html
@@ -37,10 +37,10 @@
       </nav>
     </header>
 
-    <main class="content">
+    <main class="content qualify-grid">
       <section class="savings-estimator">
         <h2>Instant Solar Savings Estimator</h2>
-        <form class="estimator-form" action="#" method="post">
+        <form class="estimator-form" action="#" method="get">
           <label for="bill">Average monthly electric bill (required)</label>
           <input type="number" id="bill" name="bill" required />
 
@@ -57,137 +57,60 @@
 
           <button type="submit">Calculate My Savings</button>
         </form>
+        <p id="savings-result"></p>
         <p>We respect your privacy. No spam. Just savings.</p>
       </section>
 
-      <h1>Solar Savings, Made Simple.</h1>
-      <p>
-        The Greensboro Net Metering Program helps homeowners save more by
-        feeding extra solar power back to the grid.
-      </p>
-      <form class="qualify-form" action="#" method="post">
-        <fieldset>
-          <legend>Basic Information</legend>
-
-          <label for="homeowner">Are you a homeowner?</label>
-          <select id="homeowner" name="homeowner" required>
-            <option value="">Select</option>
-            <option>Yes</option>
-            <option>No</option>
-          </select>
-
-          <label for="taxes">Do you file federal taxes?</label>
-          <select id="taxes" name="taxes" required>
-            <option value="">Select</option>
-            <option>Yes</option>
-            <option>No</option>
-          </select>
-
-          <label for="credit">Is your credit score above 600?</label>
-          <select id="credit" name="credit" required>
-            <option value="">Select</option>
-            <option>Yes</option>
-            <option>No</option>
-          </select>
-
-          <label for="roof">What type of roof do you have?</label>
-          <select id="roof" name="roof" required>
-            <option value="">Select</option>
-            <option>Slatted</option>
-            <option>Panels</option>
-            <option>Other</option>
-          </select>
-
-          <label for="billname">Whose name is on the electric bill?</label>
-          <input id="billname" name="billname" type="text" required />
-
-          <label for="usage">12-month usage statement (kWh)</label>
-          <input id="usage" name="usage" type="text" required />
-
-          <label for="decision">Are all decision makers present?</label>
-          <select id="decision" name="decision" required>
-            <option value="">Select</option>
-            <option>Yes</option>
-            <option>No</option>
-          </select>
-
-          <fieldset class="sub-group">
-            <legend>Do you need roof or tree removal?</legend>
-            <label
-              ><input type="checkbox" name="removal" value="roof" /> Roof
-              removal</label
-            >
-            <label
-              ><input type="checkbox" name="removal" value="tree" /> Tree
-              removal</label
-            >
-          </fieldset>
-        </fieldset>
-
-        <fieldset>
-          <legend>Energy-Efficient Upgrades in the Last 12 Months</legend>
-          <label
-            ><input type="checkbox" name="upgrades" value="insulation" />
-            Insulation</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="windows" />
-            Windows</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="water heater" />
-            Water Heater</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="HVAC" /> HVAC</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="heat pump" /> Heat
-            Pump</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="pool" /> Pool</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="pool pump" /> Pool
-            Pump</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="smart thermostat" />
-            Smart Thermostat</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="washer" />
-            Washer</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="dryer" />
-            Dryer</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="fridge" />
-            Fridge</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="freezer" />
-            Freezer</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="led lights" /> LED
-            Lights</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="doors" />
-            Doors</label
-          >
-          <label
-            ><input type="checkbox" name="upgrades" value="other" />
-            Other</label
-          >
-        </fieldset>
-
-        <button type="submit">Submit</button>
-      </form>
+      <section class="prequal-quiz">
+        <h1>Solar Savings, Made Simple.</h1>
+        <form id="quiz-form" action="thankyou.html" method="get">
+          <div class="step active">
+            <p class="message">
+              Duke Energy keeps hiking rates. What's your ZIP so we can check local
+              savings?
+            </p>
+            <label for="quiz-zip">ZIP Code</label>
+            <input type="text" id="quiz-zip" required />
+            <button type="button" class="next">Next</button>
+          </div>
+          <div class="step">
+            <p class="message">
+              Every dollar you pay Duke leaves Greensboro. About how much is your
+              monthly electric bill?
+            </p>
+            <label for="quiz-bill">Monthly Electric Bill ($)</label>
+            <input type="number" id="quiz-bill" required />
+            <button type="button" class="next">Next</button>
+          </div>
+          <div class="step">
+            <p class="message">
+              Solar works on most roofs. What type do you have?
+            </p>
+            <label for="quiz-roof">Roof Type</label>
+            <select id="quiz-roof" required>
+              <option value="">Select</option>
+              <option>Shingle</option>
+              <option>Metal</option>
+              <option>Tile</option>
+              <option>Flat</option>
+              <option>Other</option>
+            </select>
+            <button type="button" class="next">Next</button>
+          </div>
+          <div class="step">
+            <p class="message">
+              You're a great fit! Let's lock in your savings.
+            </p>
+            <label for="quiz-name">Name</label>
+            <input type="text" id="quiz-name" required />
+            <label for="quiz-email">Email</label>
+            <input type="email" id="quiz-email" required />
+            <label for="quiz-phone">Phone</label>
+            <input type="tel" id="quiz-phone" required />
+            <button type="submit">Get My Savings</button>
+          </div>
+        </form>
+      </section>
     </main>
 
     <footer>

--- a/thankyou.html
+++ b/thankyou.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Thanks - You Power You</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="css/style.css" />
+    <script defer src="js/main.js"></script>
+  </head>
+  <body>
+    <header>
+      <nav class="navbar" role="navigation">
+        <a href="index.html" class="logo">You Power You</a>
+        <button class="hamburger" aria-label="Toggle navigation" aria-controls="navigation" aria-expanded="false">☰</button>
+        <ul id="navigation" class="nav-links">
+          <li><a href="index.html#savings">Savings</a></li>
+          <li><a href="index.html#community">Community</a></li>
+          <li><a href="testimonials.html">Testimonials</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="qualify.html">Qualify</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </header>
+    <main class="content">
+      <h1>You're a great fit!</h1>
+      <p>We'll reach out soon to lock in your solar savings.</p>
+      <a href="index.html" class="cta">Back to Home</a>
+    </main>
+    <footer>
+      <div class="trust-badges">25-Year Equipment Warranty • No Upfront Costs • Locally Trusted Installers</div>
+      <p>© 2024 You Power You. All rights reserved.</p>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Use a single solar rooftop hero image
- Organize qualification panels in a responsive grid and compute savings from bill and ZIP
- Redirect multi-step quiz to a thank-you page to avoid 405 errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914c95a338832b87f2bb38d523b01d