### PR TITLE
Prevent premature navigation from quiz form

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,62 +1,81 @@
-const form = document.querySelector(".contact-form");
-if (form) {
-  form.addEventListener("submit", (e) => {
-    e.preventDefault();
-    alert("Thanks for reaching out! We will contact you soon.");
-    form.reset();
-  });
-}
-
-  const hamburger = document.querySelector(".hamburger");
-  const navLinks = document.querySelector(".nav-links");
-  if (hamburger && navLinks) {
-    hamburger.addEventListener("click", () => {
-      const expanded = hamburger.getAttribute("aria-expanded") === "true";
-      hamburger.setAttribute("aria-expanded", String(!expanded));
-      navLinks.classList.toggle("active");
-    });
+document.addEventListener("DOMContentLoaded", () => {
+  try {
+    const form = document.querySelector(".contact-form");
+    if (form) {
+      form.addEventListener("submit", (e) => {
+        e.preventDefault();
+        alert("Thanks for reaching out! We will contact you soon.");
+        form.reset();
+      });
+    }
+  } catch (err) {
+    console.error("Contact form setup failed", err);
   }
 
-  const estimator = document.querySelector(".estimator-form");
-  if (estimator) {
-    estimator.addEventListener("submit", (e) => {
-      e.preventDefault();
-      const bill = parseFloat(document.getElementById("bill").value);
-      const zip = document.getElementById("zip").value.trim();
-      if (!isNaN(bill) && zip) {
-        const monthly = bill * 0.25;
-        const yearly = monthly * 12;
-        const result = document.getElementById("savings-result");
-        if (result) {
-          result.textContent = `Homes in ${zip} could save about $${monthly.toFixed(0)} per month (~$${yearly.toFixed(0)} per year).`;
-        }
-      }
-    });
+  try {
+    const hamburger = document.querySelector(".hamburger");
+    const navLinks = document.querySelector(".nav-links");
+    if (hamburger && navLinks) {
+      hamburger.addEventListener("click", () => {
+        const expanded = hamburger.getAttribute("aria-expanded") === "true";
+        hamburger.setAttribute("aria-expanded", String(!expanded));
+        navLinks.classList.toggle("active");
+      });
+    }
+  } catch (err) {
+    console.error("Navigation setup failed", err);
   }
 
-  const quiz = document.getElementById("quiz-form");
-  if (quiz) {
-    const steps = quiz.querySelectorAll(".step");
-    let current = 0;
-
-    const showStep = (index) => {
-      steps[current].classList.remove("active");
-      current = index;
-      steps[current].classList.add("active");
-    };
-
-    quiz.querySelectorAll(".next").forEach((btn) => {
-      btn.addEventListener("click", () => {
-        const input = steps[current].querySelector("input, select");
-        if (!input || input.reportValidity()) {
-          showStep(Math.min(current + 1, steps.length - 1));
+  try {
+    const estimator = document.querySelector(".estimator-form");
+    if (estimator) {
+      estimator.addEventListener("submit", (e) => {
+        e.preventDefault();
+        const bill = parseFloat(document.getElementById("bill").value);
+        const zip = document.getElementById("zip").value.trim();
+        if (!isNaN(bill) && zip) {
+          const monthly = bill * 0.25;
+          const yearly = monthly * 12;
+          const result = document.getElementById("savings-result");
+          if (result) {
+            result.textContent = `Homes in ${zip} could save about $${monthly.toFixed(0)} per month (~$${yearly.toFixed(0)} per year).`;
+          }
         }
       });
-    });
+    }
+  } catch (err) {
+    console.error("Estimator setup failed", err);
+  }
 
-    quiz.addEventListener("submit", (e) => {
-      e.preventDefault();
-      window.location.href = "thankyou.html";
-    });
+  try {
+    const quiz = document.getElementById("quiz-form");
+    if (quiz) {
+      const steps = quiz.querySelectorAll(".step");
+      let current = 0;
+
+      const showStep = (index) => {
+        steps[current].classList.remove("active");
+        current = index;
+        steps[current].classList.add("active");
+      };
+
+      quiz.querySelectorAll(".next").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const input = steps[current].querySelector("input, select");
+          if (!input || input.reportValidity()) {
+            showStep(Math.min(current + 1, steps.length - 1));
+          }
+        });
+      });
+
+      quiz.addEventListener("submit", (e) => {
+        e.preventDefault();
+        window.location.href = "thankyou.html";
+      });
+      console.log("Quiz form listener attached");
+    }
+  } catch (err) {
+    console.error("Quiz form setup failed", err);
   }
 });
+

--- a/qualify.html
+++ b/qualify.html
@@ -63,7 +63,7 @@
 
       <section class="prequal-quiz">
         <h1>Solar Savings, Made Simple.</h1>
-        <form id="quiz-form" action="thankyou.html" method="get">
+        <form id="quiz-form" action="#" method="get">
           <div class="step active">
             <p class="message">
               Duke Energy keeps hiking rates. What's your ZIP so we can check local


### PR DESCRIPTION
## Summary
- Avoid navigation when quiz script isn’t loaded by neutralizing the form action
- Isolate site scripts with defensive try/catch blocks and log quiz listener attachment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916a6aaefc832baa7b0b9a601acd02