### PR TITLE
Add worker and infographic images to about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -50,8 +50,13 @@
         roof.
       </p>
       <img
-        src="https://via.placeholder.com/600x400?text=Community+Benefits"
-        alt="Infographic showing community benefits of local solar adoption"
+        src="assets/solar-hero-worker-image.png"
+        alt="Local Greensboro solar installation crew working on a roof."
+        class="feature-image"
+      />
+      <img
+        src="assets/solar-savings-infographic.png"
+        alt="Infographic showing potential monthly and yearly savings for Greensboro homeowners"
         class="infographic"
       />
     </main>

--- a/css/style.css
+++ b/css/style.css
@@ -86,12 +86,13 @@ body {
   background: #e3f2fd;
 }
 
-.infographic {
-  width: 100%;
-  max-width: 600px;
-  height: auto;
-  margin-top: 1rem;
-}
+  .infographic,
+  .feature-image {
+    width: 100%;
+    max-width: 600px;
+    height: auto;
+    margin-top: 1rem;
+  }
 
 .content {
   padding: 2rem;


### PR DESCRIPTION
## Summary
- Embed local worker photo on About page and include savings infographic
- Share styling between feature and infographic images

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892632e9920832b9934715e8da9f84b