### PR TITLE
style: make images full width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -89,10 +89,10 @@ body {
 .infographic,
 .feature-image {
   display: block;
-  width: 100%;
-  max-width: 600px;
+  width: calc(100% + 4rem);
+  max-width: none;
   height: auto;
-  margin: 1rem auto 0;
+  margin: 1rem -2rem 0;
 }
 
 .content {

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
       <img
         src="assets/solar-hero-worker-image.png"
         alt="Local Greensboro solar installation crew working on a roof."
+        class="feature-image"
       />
     </section>
 


### PR DESCRIPTION
## Summary
- Display savings infographic on the homepage
- Allow infographics and feature images to span edge-to-edge on pages
- Apply full-width styling to community section image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689271ac42ac832b98b4f13b6995bc54