### PR TITLE
feat: factor usage and rate hikes into savings calc

### DIFF
--- a/qualifier.html
+++ b/qualifier.html
@@ -129,6 +129,7 @@
                         <div id="check3" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                         <div id="check4" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                         <div id="check5" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
+                        <div id="check6" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                     </div>
                 </div>
 
@@ -232,6 +233,21 @@
                         </div>
                     </fieldset>
 
+                    <!-- Question 6 (NEW): Yearly Usage -->
+                    <fieldset class="qualification-question" id="usage-fieldset">
+                        <legend id="usage-label" class="flex items-center mb-3 text-lg font-medium text-gray-700">
+                            What’s your yearly electricity usage from your last utility statement? (kWh/year)
+                            <button type="button" class="ml-2 w-5 h-5 bg-brandOrange text-white rounded-full text-xs flex items-center justify-center tooltip-btn" data-target="usage-tooltip" aria-label="Where to find yearly usage">?</button>
+                        </legend>
+                        <div id="usage-tooltip" class="tooltip bg-gray-800 text-white p-3 rounded-lg mb-3 text-sm" role="tooltip">
+                            Check your utility’s annual summary or last 12 bills. It’s OK to leave blank if you don’t know yet.
+                        </div>
+                        <div class="max-w-sm">
+                            <input type="number" id="annualUsageKWh" min="100" step="1" placeholder="e.g., 12000" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
+                            <p class="text-xs text-gray-500 mt-1">Optional, but improves the accuracy of your savings estimate.</p>
+                        </div>
+                    </fieldset>
+
                     <div class="flex justify-between pt-6">
                         <button type="button" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors back-btn">Back</button>
                         <button type="submit" class="bg-gradient-to-r from-brandGreen to-brandOrange hover:from-brandGreen/90 hover:to-brandOrange/90 text-white font-bold py-3 px-6 rounded-lg transition-all">Continue</button>
@@ -327,7 +343,7 @@
         <div id="screen5" class="screen hidden">
             <div class="bg-white rounded-2xl shadow-xl p-8">
                 <h2 class="text-3xl font-bold text-gray-800 mb-6 text-center">Estimate Your Savings</h2>
-                <p class="text-lg text-gray-600 mb-8 text-center">Enter your current electric bill and annual rate increase.</p>
+                <p class="text-lg text-gray-600 mb-8 text-center">Enter your current average bill and the expected utility rate hike. If you know your yearly usage (Step 3), we’ll apply a more accurate markdown.</p>
                 <form id="savingsForm" class="space-y-4 mb-8">
                     <div>
                         <label for="monthlyBill" class="block text-sm font-medium text-gray-700 mb-2">Average Monthly Electric Bill ($)</label>
@@ -348,6 +364,7 @@
                 <div id="savingsResult" class="hidden">
                     <canvas id="savingsChart" height="200"></canvas>
                     <p id="savingsNote" class="text-center mt-4 text-lg font-semibold text-brandGreen"></p>
+                    <p id="usageReminder" class="text-center mt-2 text-sm text-gray-500 hidden">For a more accurate markdown, add your yearly usage on Step 3.</p>
                     <div class="flex justify-between pt-6">
                         <button type="button" id="recalc" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors">Back</button>
                         <button type="button" id="calcContinue" class="bg-gradient-to-r from-brandGreen to-brandOrange hover:from-brandGreen/90 hover:to-brandOrange/90 text-white font-bold py-3 px-6 rounded-lg transition-all">Continue</button>


### PR DESCRIPTION
## Summary
- capture optional yearly electricity usage in Step 3 and persist into savings calculator
- project 25-year bills with rate-hike schedule and solar markdown, displaying No Solar vs With Solar chart
- show reminder when usage is missing for more accurate markdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2bd08d58832bae439a1769fc20d0