### PR TITLE
feat: factor usage and rate hikes into savings calc

### DIFF
--- a/qualifier.html
+++ b/qualifier.html
@@ -129,6 +129,7 @@
                         <div id="check3" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                         <div id="check4" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                         <div id="check5" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
+                        <div id="check6" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                     </div>
                 </div>
 
@@ -232,6 +233,21 @@
                         </div>
                     </fieldset>
 
+                    <!-- Question 6 (NEW): Yearly Usage -->
+                    <fieldset class="qualification-question" id="usage-fieldset">
+                        <legend id="usage-label" class="flex items-center mb-3 text-lg font-medium text-gray-700">
+                            What’s your yearly electricity usage from your last utility statement? (kWh/year)
+                            <button type="button" class="ml-2 w-5 h-5 bg-brandOrange text-white rounded-full text-xs flex items-center justify-center tooltip-btn" data-target="usage-tooltip" aria-label="Where to find yearly usage">?</button>
+                        </legend>
+                        <div id="usage-tooltip" class="tooltip bg-gray-800 text-white p-3 rounded-lg mb-3 text-sm" role="tooltip">
+                            Check your utility’s annual summary or last 12 bills. It’s OK to leave blank if you don’t know yet.
+                        </div>
+                        <div class="max-w-sm">
+                            <input type="number" id="annualUsageKWh" min="100" step="1" placeholder="e.g., 12000" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
+                            <p class="text-xs text-gray-500 mt-1">Optional, but improves the accuracy of your savings estimate.</p>
+                        </div>
+                    </fieldset>
+
                     <div class="flex justify-between pt-6">
                         <button type="button" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors back-btn">Back</button>
                         <button type="submit" class="bg-gradient-to-r from-brandGreen to-brandOrange hover:from-brandGreen/90 hover:to-brandOrange/90 text-white font-bold py-3 px-6 rounded-lg transition-all">Continue</button>
@@ -325,35 +341,52 @@
 
         <!-- Screen 5: Savings Calculator -->
         <div id="screen5" class="screen hidden">
-            <div class="bg-white rounded-2xl shadow-xl p-8">
-                <h2 class="text-3xl font-bold text-gray-800 mb-6 text-center">Estimate Your Savings</h2>
-                <p class="text-lg text-gray-600 mb-8 text-center">Enter your current electric bill and annual rate increase.</p>
-                <form id="savingsForm" class="space-y-4 mb-8">
-                    <div>
-                        <label for="monthlyBill" class="block text-sm font-medium text-gray-700 mb-2">Average Monthly Electric Bill ($)</label>
-                        <input type="number" id="monthlyBill" required class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
-                    </div>
-                    <div>
-                        <label for="rateIncrease" class="block text-sm font-medium text-gray-700 mb-2">Expected Annual Utility Rate Increase (%)</label>
-                        <input type="number" id="rateIncrease" value="3" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
-                    </div>
-                    <div class="flex justify-between pt-4">
-                        <button type="button" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors back-btn">Back</button>
-                        <div class="space-x-2">
-                            <button type="button" id="skipCalc" class="bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors">Skip</button>
-                            <button type="submit" class="bg-gradient-to-r from-brandGreen to-brandOrange hover:from-brandGreen/90 hover:to-brandOrange/90 text-white font-bold py-3 px-6 rounded-lg transition-all">Calculate</button>
-                        </div>
-                    </div>
-                </form>
-                <div id="savingsResult" class="hidden">
-                    <canvas id="savingsChart" height="200"></canvas>
-                    <p id="savingsNote" class="text-center mt-4 text-lg font-semibold text-brandGreen"></p>
-                    <div class="flex justify-between pt-6">
-                        <button type="button" id="recalc" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors">Back</button>
-                        <button type="button" id="calcContinue" class="bg-gradient-to-r from-brandGreen to-brandOrange hover:from-brandGreen/90 hover:to-brandOrange/90 text-white font-bold py-3 px-6 rounded-lg transition-all">Continue</button>
-                    </div>
+          <div class="bg-white rounded-2xl shadow-xl p-8">
+            <h2 class="text-3xl font-bold text-gray-800 mb-6 text-center">Estimate Your Savings</h2>
+            <p class="text-lg text-gray-600 mb-8 text-center">
+              Enter your current average bill. We’ll project your costs using the approved NC rate path.
+            </p>
+
+            <form id="savingsForm" class="space-y-4 mb-8">
+              <div>
+                <label for="monthlyBill" class="block text-sm font-medium text-gray-700 mb-2">
+                  Average Monthly Electric Bill ($)
+                </label>
+                <input type="number" id="monthlyBill" required min="10" step="1"
+                       class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
+              </div>
+
+              <div class="flex justify-between pt-4">
+                <button type="button" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors back-btn">
+                  Back
+                </button>
+                <div class="space-x-2">
+                  <button type="button" id="skipCalc" class="bg-gray-200 hover:bg-gray-300 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors">
+                    Skip
+                  </button>
+                  <button type="submit" class="bg-gradient-to-r from-brandGreen to-brandOrange hover:from-brandGreen/90 hover:to-brandOrange/90 text-white font-bold py-3 px-6 rounded-lg transition-all">
+                    Calculate
+                  </button>
                 </div>
+              </div>
+            </form>
+
+            <div id="savingsResult" class="hidden">
+              <canvas id="savingsChart" height="220"></canvas>
+              <p id="savingsNote" class="text-center mt-4 text-lg font-semibold text-brandGreen"></p>
+              <p class="text-center mt-1 text-sm text-gray-500 italic">
+                “Assuming Duke <em>never raises rates again</em>” shown as the flat series.
+              </p>
+              <div class="flex justify-between pt-6">
+                <button type="button" id="recalc" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors">
+                  Back
+                </button>
+                <button type="button" id="calcContinue" class="bg-gradient-to-r from-brandGreen to-brandOrange hover:from-brandGreen/90 hover:to-brandOrange/90 text-white font-bold py-3 px-6 rounded-lg transition-all">
+                  Continue
+                </button>
+              </div>
             </div>
+          </div>
         </div>
 
         <!-- Screen 6: Scheduling -->
@@ -452,6 +485,7 @@
         </div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="js/qualifier.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- streamline savings calculator to only require monthly bill and project costs using NC's rate path
- compare current trend vs. frozen rates in an annotated area chart
- load Chart.js annotation plugin for inflection markers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2bd08d58832bae439a1769fc20d0