### PR TITLE
Align qualifier assets with available images

### DIFF
--- a/qualifier.html
+++ b/qualifier.html
@@ -48,7 +48,7 @@
         <div class="mb-8 p-4 rounded-2xl bg-white">
             <div class="relative bg-gray-200 rounded-full h-2">
                 <div id="progressBar" class="bg-gradient-to-r from-brandGreen to-brandYellow h-2 rounded-full progress-bar" style="width: 14.3%"></div>
-                <img id="progressSun" src="assets/spliced_social_icons/solar.png" alt="Sun" class="absolute -top-2 left-0 w-6 h-6 transition-all duration-500">
+                <img id="progressSun" src="assets/qualify_assets/house-icon-transparent.png" alt="House icon" class="absolute -top-2 left-0 w-6 h-6 transition-all duration-500">
             </div>
             <div class="text-center mt-2 text-sm text-gray-600">
                 Step <span id="currentStep">1</span> of 7
@@ -60,7 +60,7 @@
             <div class="text-center bg-white rounded-2xl shadow-xl p-8 md:p-12">
                 <!-- Solar Home Visual -->
                 <div class="mb-8">
-                    <img src="assets/house-icon.png" alt="House icon" class="w-40 mx-auto" />
+                    <img src="assets/qualify_assets/house-icon-transparent.png" alt="House icon" class="w-40 mx-auto" />
                 </div>
                 
                 <h1 class="text-4xl md:text-5xl font-bold text-gray-800 mb-4">Check Your Solar Savings in Minutes</h1>
@@ -74,7 +74,7 @@
             <div class="bg-white rounded-2xl shadow-xl p-8">
                 <!-- Greensboro Skyline Visual -->
                 <div class="mb-6">
-                    <img src="assets/city-icon.png" alt="City icon" class="w-40 mx-auto" />
+                    <img src="assets/qualify_assets/city-icon-transparent.png" alt="City icon" class="w-40 mx-auto" />
                 </div>
 
                 <h2 class="text-3xl font-bold text-gray-800 mb-6 text-center">Tell Us About Your Home</h2>
@@ -265,63 +265,51 @@
                 <form id="upgradesForm">
                     <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="insulation" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/insulation.png" alt="Insulation" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/insulation.png" alt="Insulation" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Insulation</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="windows" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/windows.png" alt="Windows" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/windows.png" alt="Windows" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Windows</div>
                         </button>
-                        <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="water_heater" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/question.png" alt="Water Heater" class="w-8 h-8 object-contain mx-auto mb-2" />
-                            <div class="text-sm font-medium">Water Heater</div>
-                        </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="hvac" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/hvac.png" alt="HVAC" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/hvac.png" alt="HVAC" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">HVAC</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="heat_pump" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/hvac.png" alt="Heat Pump" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/hvac.png" alt="Heat Pump" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Heat Pump</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="pool" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/pool.png" alt="Pool" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/pool.png" alt="Pool" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Pool</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="pool_pump" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/pool_pump.png" alt="Pool Pump" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/pool-pump.png" alt="Pool Pump" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Pool Pump</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="thermostat" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/smart_thermostat.png" alt="Smart Thermostat" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/smart-thermostat.png" alt="Smart Thermostat" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Smart Thermostat</div>
                         </button>
-                        <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="washer" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/washer.png" alt="Washer" class="w-8 h-8 object-contain mx-auto mb-2" />
-                            <div class="text-sm font-medium">Washer</div>
-                        </button>
-                        <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="dryer" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/dryer.png" alt="Dryer" class="w-8 h-8 object-contain mx-auto mb-2" />
-                            <div class="text-sm font-medium">Dryer</div>
-                        </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="fridge" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/freezer.png" alt="Fridge" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/fridge.png" alt="Fridge" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Fridge</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="freezer" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/freezer.png" alt="Freezer" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/freezer.png" alt="Freezer" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Freezer</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="led_lights" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/led_lights.png" alt="LED Lights" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/led-lights.png" alt="LED Lights" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">LED Lights</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="doors" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/doors.png" alt="Doors" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/doors.png" alt="Doors" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Doors</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="other" aria-pressed="false">
-                            <img src="assets/spliced_energy_icons_final/other.png" alt="Other" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/other.png" alt="Other" class="w-8 h-8 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Other</div>
                         </button>
                     </div>


### PR DESCRIPTION
## Summary
- Route progress bar and initial screen images to `qualify_assets`
- Use existing `qualify_assets` icons for energy upgrade options
- Remove upgrade options lacking corresponding assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b7778ced8832b8ea5d2918441426e