### PR TITLE
Handle annual bill input and stabilize savings chart

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -31,9 +31,11 @@ document.addEventListener("DOMContentLoaded", () => {
     if (estimator) {
       estimator.addEventListener("submit", (e) => {
         e.preventDefault();
-        const bill = parseFloat(document.getElementById("bill").value);
+        let bill = parseFloat(document.getElementById("bill").value);
         const zip = document.getElementById("zip").value.trim();
         if (!isNaN(bill) && zip) {
+          // convert annual entries to monthly averages if the value seems too large
+          if (bill > 1000) bill = bill / 12;
           const monthly = bill * 0.25;
           const yearly = monthly * 12;
           const result = document.getElementById("savings-result");

--- a/js/qualifier.js
+++ b/js/qualifier.js
@@ -177,6 +177,9 @@ function formatCurrency(v) {
 
     if (chart) chart.destroy();
 
+    // show result container before rendering so Chart.js can size correctly
+    resultWrap.classList.remove('hidden');
+
     chart = new Chart(ctx, {
       type: 'line',
       data: {
@@ -238,14 +241,14 @@ function formatCurrency(v) {
         }
       }
     });
-
-    resultWrap.classList.remove('hidden');
   }
 
   form.addEventListener('submit', e => {
     e.preventDefault();
-    const bill = Number(inputBill.value);
+    let bill = Number(inputBill.value);
     if (!bill || bill < 10) return;
+    // treat large values as yearly totals and convert to monthly average
+    if (bill > 1000) bill = bill / 12;
     const series = buildSeries(bill);
     renderChart(series);
   });

--- a/qualifier.html
+++ b/qualifier.html
@@ -338,7 +338,7 @@
             <form id="savingsForm" class="space-y-4 mb-8">
               <div>
                 <label for="monthlyBill" class="block text-sm font-medium text-gray-700 mb-2">
-                  Average Monthly Electric Bill ($)
+                  Average Monthly Electric Bill ($ or yearly total)
                 </label>
                 <input type="number" id="monthlyBill" required min="10" step="1"
                        class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">


### PR DESCRIPTION
## Summary
- Prevent savings chart from inflating by displaying its container before Chart.js renders
- Interpret annual bill values as monthly averages in savings calculator and estimator
- Note in form label that yearly totals are accepted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b83eaf26c832ba052e1417271f80b