### PR TITLE
Handle annual usage input and stabilize savings chart

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -31,9 +31,11 @@ document.addEventListener("DOMContentLoaded", () => {
     if (estimator) {
       estimator.addEventListener("submit", (e) => {
         e.preventDefault();
-        const bill = parseFloat(document.getElementById("bill").value);
+        let bill = parseFloat(document.getElementById("bill").value);
         const zip = document.getElementById("zip").value.trim();
         if (!isNaN(bill) && zip) {
+          // convert annual entries to monthly averages if the value seems too large
+          if (bill > 1000) bill = bill / 12;
           const monthly = bill * 0.25;
           const yearly = monthly * 12;
           const result = document.getElementById("savings-result");

--- a/js/qualifier.js
+++ b/js/qualifier.js
@@ -1,8 +1,6 @@
 let currentScreen = 1;
 let selectedUpgrades = [];
 let currentTestimonial = 0;
-let progressSun;
-let savingsChartInstance = null;
 
 const CONFIG = {
   termYears: 25,
@@ -37,13 +35,6 @@ function updateProgressBar() {
   const bar = document.getElementById('progressBar');
   bar.style.width = progress + '%';
   document.getElementById('currentStep').textContent = currentScreen;
-
-  if (progressSun) {
-    const container = bar.parentElement;
-    const maxLeft = container.offsetWidth - progressSun.offsetWidth;
-    const ratio = (currentScreen - 1) / (totalScreens - 1);
-    progressSun.style.left = maxLeft * ratio + 'px';
-  }
 }
 
 function showTooltip(id) {
@@ -119,6 +110,7 @@ function formatCurrency(v) {
 (function initSavings() {
   const form = document.getElementById('savingsForm');
   const inputBill = document.getElementById('monthlyBill');
+  const usageInput = document.getElementById('annualUsageKWh');
   const resultWrap = document.getElementById('savingsResult');
   const note = document.getElementById('savingsNote');
   const recalcBtn = document.getElementById('recalc');
@@ -175,7 +167,16 @@ function formatCurrency(v) {
     const delta = totalTrend - totalFlat;
     note.textContent = `20‑year exposure difference: ${formatCurrency(delta)} (trend vs. flat).`;
 
-    if (chart) chart.destroy();
+    if (chart) {
+      chart.destroy();
+      const parent = ctx.canvas.parentNode;
+      if (parent && parent.style) parent.style.height = '';
+    }
+
+    // show result container before rendering so Chart.js can size correctly
+    resultWrap.classList.remove('hidden');
+    // hide the form while displaying the chart
+    form.classList.add('hidden');
 
     chart = new Chart(ctx, {
       type: 'line',
@@ -238,17 +239,43 @@ function formatCurrency(v) {
         }
       }
     });
-
-    resultWrap.classList.remove('hidden');
   }
 
   form.addEventListener('submit', e => {
     e.preventDefault();
-    const bill = Number(inputBill.value);
+    let bill = Number(inputBill.value);
+
+    // Infer monthly bill if only yearly usage is provided
+    if ((!bill || bill < 10) && usageInput && usageInput.value) {
+      const kwhYear = Number(usageInput.value);
+      if (kwhYear && kwhYear > 100) {
+        const estRate = 0.14;
+        const monthlyFromKwh = (kwhYear * estRate) / 12 + CONFIG.baseFixedFeeUsd;
+        bill = monthlyFromKwh;
+      }
+    }
+
+    // Normalize annual dollar totals to monthly
+    if (bill > 1000) bill = bill / 12;
+
     if (!bill || bill < 10) return;
+
     const series = buildSeries(bill);
     renderChart(series);
   });
+
+  if (usageInput) {
+    usageInput.addEventListener('blur', () => {
+      if (!inputBill.value && usageInput.value) {
+        const kwhYear = Number(usageInput.value);
+        if (kwhYear > 100) {
+          const estRate = 0.14;
+          const monthlyFromKwh = (kwhYear * estRate) / 12 + CONFIG.baseFixedFeeUsd;
+          inputBill.value = Math.round(monthlyFromKwh);
+        }
+      }
+    });
+  }
 
   skipBtn.addEventListener('click', () => {
     const series = buildSeries(150);
@@ -257,6 +284,7 @@ function formatCurrency(v) {
 
   recalcBtn.addEventListener('click', () => {
     resultWrap.classList.add('hidden');
+    form.classList.remove('hidden');
   });
 
   continueBtn.addEventListener('click', () => {
@@ -301,7 +329,6 @@ function restartQualifier() {
 // Event bindings
 
 document.addEventListener('DOMContentLoaded', () => {
-  progressSun = document.getElementById('progressSun');
   updateProgressBar();
 
   document.getElementById('startBtn').addEventListener('click', nextScreen);

--- a/qualifier.html
+++ b/qualifier.html
@@ -48,7 +48,6 @@
         <div class="mb-8 p-4 rounded-2xl bg-white">
             <div class="relative bg-gray-200 rounded-full h-2">
                 <div id="progressBar" class="bg-gradient-to-r from-brandGreen to-brandYellow h-2 rounded-full progress-bar" style="width: 14.3%"></div>
-                <img id="progressSun" src="assets/qualify_assets/house-icon-transparent.png" alt="House icon" class="absolute -top-2 left-0 w-6 h-6 transition-all duration-500">
             </div>
             <div class="text-center mt-2 text-sm text-gray-600">
                 Step <span id="currentStep">1</span> of 7
@@ -265,51 +264,51 @@
                 <form id="upgradesForm">
                     <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="insulation" aria-pressed="false">
-                            <img src="assets/qualify_assets/insulation.png" alt="Insulation" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/insulation.png" alt="Insulation" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Insulation</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="windows" aria-pressed="false">
-                            <img src="assets/qualify_assets/windows.png" alt="Windows" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/windows.png" alt="Windows" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Windows</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="hvac" aria-pressed="false">
-                            <img src="assets/qualify_assets/hvac.png" alt="HVAC" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/hvac.png" alt="HVAC" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">HVAC</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="heat_pump" aria-pressed="false">
-                            <img src="assets/qualify_assets/hvac.png" alt="Heat Pump" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/hvac.png" alt="Heat Pump" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Heat Pump</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="pool" aria-pressed="false">
-                            <img src="assets/qualify_assets/pool.png" alt="Pool" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/pool.png" alt="Pool" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Pool</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="pool_pump" aria-pressed="false">
-                            <img src="assets/qualify_assets/pool-pump.png" alt="Pool Pump" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/pool-pump.png" alt="Pool Pump" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Pool Pump</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="thermostat" aria-pressed="false">
-                            <img src="assets/qualify_assets/smart-thermostat.png" alt="Smart Thermostat" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/smart-thermostat.png" alt="Smart Thermostat" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Smart Thermostat</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="fridge" aria-pressed="false">
-                            <img src="assets/qualify_assets/fridge.png" alt="Fridge" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/fridge.png" alt="Fridge" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Fridge</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="freezer" aria-pressed="false">
-                            <img src="assets/qualify_assets/freezer.png" alt="Freezer" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/freezer.png" alt="Freezer" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Freezer</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="led_lights" aria-pressed="false">
-                            <img src="assets/qualify_assets/led-lights.png" alt="LED Lights" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/led-lights.png" alt="LED Lights" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">LED Lights</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="doors" aria-pressed="false">
-                            <img src="assets/qualify_assets/doors.png" alt="Doors" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/doors.png" alt="Doors" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Doors</div>
                         </button>
                         <button type="button" class="upgrade-icon text-center p-4 border-2 border-gray-200 rounded-lg cursor-pointer hover:border-brandOrange transition-all" data-upgrade="other" aria-pressed="false">
-                            <img src="assets/qualify_assets/other.png" alt="Other" class="w-8 h-8 object-contain mx-auto mb-2" />
+                            <img src="assets/qualify_assets/other.png" alt="Other" class="w-12 h-12 object-contain mx-auto mb-2" />
                             <div class="text-sm font-medium">Other</div>
                         </button>
                     </div>
@@ -338,7 +337,7 @@
             <form id="savingsForm" class="space-y-4 mb-8">
               <div>
                 <label for="monthlyBill" class="block text-sm font-medium text-gray-700 mb-2">
-                  Average Monthly Electric Bill ($)
+                  Average Monthly Electric Bill ($ or yearly total)
                 </label>
                 <input type="number" id="monthlyBill" required min="10" step="1"
                        class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
@@ -360,7 +359,9 @@
             </form>
 
             <div id="savingsResult" class="hidden">
-              <canvas id="savingsChart" height="220"></canvas>
+              <div class="relative h-56 md:h-64">
+                <canvas id="savingsChart"></canvas>
+              </div>
               <p id="savingsNote" class="text-center mt-4 text-lg font-semibold text-brandGreen"></p>
               <p class="text-center mt-1 text-sm text-gray-500 italic">
                 “Assuming Duke <em>never raises rates again</em>” shown as the flat series.


### PR DESCRIPTION
## Summary
- Replace canvas height hacks with a fixed-height wrapper and reset chart sizing on destroy
- Infer monthly bill from annual kWh usage and autofill the form when possible
- Enlarge upgrade icons and remove stray progress-bar image

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b83eaf26c832ba052e1417271f80b