### PR TITLE
Add roof images and reorder qualification questions

### DIFF
--- a/js/qualifier.js
+++ b/js/qualifier.js
@@ -27,7 +27,6 @@ function getUsageKWh() {
 const CONFIG = {
   termYears: 25,
   baseFixedFeeUsd: 25,
-  fixedEscalationPct: 0.02, // used only if the solar escalator toggle is ON
   offsetPct: 0.90,          // solar payment is ~90% of current bill by default
   NET_METERING_DEADLINE: new Date(new Date().getFullYear() + 1, 6, 1) // July=6 (0-indexed)
 };
@@ -123,14 +122,13 @@ function inferMonthlyBill({ monthlyInput, carriedAnnualKWh }) {
   return (bill && bill >= 10) ? bill : null;
 }
 
-// ===== Long-term (annual) series with optional solar flat/escalator =====
-function buildSeriesWithSolar_dateBased(startMonthly, solarStartsAtMonthIndex, useSolarEscalator, utility = 'DEC') {
+// ===== Long-term (annual) series with flat solar comparison =====
+function buildSeriesWithSolar_dateBased(startMonthly, solarStartsAtMonthIndex, utility = 'DEC') {
   const hikes = (DUKE_RATE_SCHEDULE[utility] || []).map(h => ({ ym: parseYM(h.effective), pct: h.pct }));
   hikes.sort((a, b) => a.ym - b.ym);
 
   const today = new Date();
   const start = new Date(today.getFullYear(), today.getMonth(), 1);
-  const end = new Date(start.getFullYear() + HORIZON_YEARS, start.getMonth(), 1);
 
   const months = [];
   let cur = new Date(start);
@@ -139,13 +137,13 @@ function buildSeriesWithSolar_dateBased(startMonthly, solarStartsAtMonthIndex, u
 
   const flatMonthly = startMonthly;
 
-  while (cur <= end) {
+  for (let i = 0; i < HORIZON_YEARS * 12; i++) {
     const curYM = ym(cur);
-    for (let i = lastHikeIndexApplied + 1; i < hikes.length; i++) {
-      if (hikes[i].ym === curYM) {
-        monthly *= (1 + hikes[i].pct);
-        lastHikeIndexApplied = i;
-      } else if (hikes[i].ym > curYM) { break; }
+    for (let j = lastHikeIndexApplied + 1; j < hikes.length; j++) {
+      if (hikes[j].ym === curYM) {
+        monthly *= (1 + hikes[j].pct);
+        lastHikeIndexApplied = j;
+      } else if (hikes[j].ym > curYM) { break; }
     }
     if (lastHikeIndexApplied === hikes.length - 1 && hikes.length > 0) {
       monthly = monthly * Math.pow(1 + POST_TREND, 1/12);
@@ -162,13 +160,12 @@ function buildSeriesWithSolar_dateBased(startMonthly, solarStartsAtMonthIndex, u
 
   const years = []; const trend = []; const flat = []; const solar = [];
   const baseMonthlySolar = startMonthly * CONFIG.offsetPct + CONFIG.baseFixedFeeUsd;
-  const solarStartYear = Math.floor(solarStartsAtMonthIndex / 12);
+  const solarStartYear = Math.floor(solarStartsAtMonthIndex / 12) + 1;
 
-  for (let y = 0; y <= HORIZON_YEARS; y++) {
+  for (let y = 1; y <= HORIZON_YEARS; y++) {
     years.push(y);
-    const startIdx = y * 12;
-    const endIdx = Math.min(startIdx + 12, months.length);
-    const slice = months.slice(startIdx, endIdx);
+    const startIdx = (y - 1) * 12;
+    const slice = months.slice(startIdx, startIdx + 12);
 
     const yearTrend = slice.reduce((s, m) => s + m.utilityTrendMonthly, 0);
     const yearFlat = slice.reduce((s, m) => s + m.utilityFlatMonthly, 0);
@@ -179,11 +176,7 @@ function buildSeriesWithSolar_dateBased(startMonthly, solarStartsAtMonthIndex, u
     if (y < solarStartYear) {
       solar.push(null);
     } else {
-      const yearsSince = y - solarStartYear;
-      const monthlySolar = useSolarEscalator
-        ? baseMonthlySolar * Math.pow(1 + CONFIG.fixedEscalationPct, Math.max(0, yearsSince))
-        : baseMonthlySolar;
-      solar.push(monthlySolar * 12);
+      solar.push(baseMonthlySolar * 12);
     }
   }
 
@@ -241,17 +234,21 @@ function formatCurrency(v) {
   const form = document.getElementById('savingsForm');
   const inputBill = document.getElementById('monthlyBill');
   const installMonthInput = document.getElementById('installMonth');
-  const useEscalatorInput = document.getElementById('solarEscalator');
 
   (function seedMonthlyFromUsage() {
     const carried = appState.annualUsageKWh ?? getUsageKWh();
-    if (!carried) return;
+    if (!carried) return; // Step 3 now required, but guard anyway
     const estRate = 0.14;
-    const estimatedMonthly = Math.round((carried * estRate) / 12 + CONFIG.baseFixedFeeUsd);
-    if (!inputBill.value) inputBill.value = estimatedMonthly;
+    const monthlyFromUsage = Math.round((carried * estRate) / 12 + CONFIG.baseFixedFeeUsd);
+
+    inputBill.value = monthlyFromUsage;
+    inputBill.readOnly = true;
+    inputBill.setAttribute('aria-readonly', 'true');
+    inputBill.classList.add('bg-gray-50');
+
     const helper = document.createElement('p');
     helper.className = 'text-xs text-gray-500 mt-1';
-    helper.textContent = `Estimated from your 12-month usage: about $${estimatedMonthly}/mo (at $${estRate.toFixed(2)}/kWh + $${CONFIG.baseFixedFeeUsd} fixed).`;
+    helper.textContent = `Calculated from your 12-month usage: ~$${monthlyFromUsage}/mo (at $${estRate.toFixed(2)}/kWh + $${CONFIG.baseFixedFeeUsd} fixed).`;
     inputBill.parentElement.appendChild(helper);
   })();
 
@@ -334,11 +331,6 @@ function formatCurrency(v) {
 
     const { years, trend, flat, solar } = series;
 
-    const totalTrend = trend.reduce((a, b) => a + b, 0);
-    const totalFlat = flat.reduce((a, b) => a + b, 0);
-    const delta = totalTrend - totalFlat;
-    note.textContent = `20‑year exposure difference (trend vs. flat utility): ${formatCurrency(delta)}.`;
-
     longChart = new Chart(longCtx, {
       type: 'line',
       data: {
@@ -352,18 +344,18 @@ function formatCurrency(v) {
             backgroundColor: 'rgba(44,85,48,0.18)',
             tension: 0.25,
             borderWidth: 2,
-            pointRadius: ctx => ([5,10,15,20].includes(ctx.dataIndex) ? 4 : 0),
+            pointRadius: ctx => ([4,9,14,19].includes(ctx.dataIndex) ? 4 : 0),
             pointBackgroundColor: '#2c5530'
           },
           {
-            label: 'Utility (never raises rates again)',
+            label: 'Utility (flat rates)',
             data: flat,
             fill: true,
             borderColor: '#ff914d',
             backgroundColor: 'rgba(255,145,77,0.15)',
             tension: 0.25,
             borderWidth: 2,
-            pointRadius: ctx => ([5,10,15,20].includes(ctx.dataIndex) ? 3 : 0),
+            pointRadius: ctx => ([4,9,14,19].includes(ctx.dataIndex) ? 3 : 0),
             pointBackgroundColor: '#ff914d'
           },
           {
@@ -401,12 +393,10 @@ function formatCurrency(v) {
   }
 
   function handleSubmit() {
-    const monthlyInput = Number(inputBill.value);
-    const monthly = inferMonthlyBill({
-      monthlyInput,
-      carriedAnnualKWh: appState.annualUsageKWh ?? getUsageKWh()
-    });
-    if (!monthly) return;
+    const carried = appState.annualUsageKWh ?? getUsageKWh();
+    if (!carried) { showScreen(3); return; }
+    const estRate = 0.14;
+    const monthly = (carried * estRate) / 12 + CONFIG.baseFixedFeeUsd;
 
     const today = new Date();
     let solarStartIndex = 0;
@@ -417,15 +407,13 @@ function formatCurrency(v) {
       solarStartIndex = Math.max(0, diffMonths);
     }
 
-    const useEscalator = !!useEscalatorInput.checked;
-
     resultWrap.classList.remove('hidden');
     form.classList.add('hidden');
 
     const nearSeries = buildNearTermMonthlySeries(monthly, appState.utility, today);
     renderNearTermChart(nearSeries);
 
-    const longSeries = buildSeriesWithSolar_dateBased(monthly, solarStartIndex, useEscalator, appState.utility);
+    const longSeries = buildSeriesWithSolar_dateBased(monthly, solarStartIndex, appState.utility);
     renderLongTermChart(longSeries);
 
     const assumedMonthlySolar = Math.round(monthly * CONFIG.offsetPct + CONFIG.baseFixedFeeUsd);
@@ -505,13 +493,17 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('.back-btn').forEach(btn => btn.addEventListener('click', prevScreen));
   document.getElementById('restartBtn').addEventListener('click', restartQualifier);
 
-  document.getElementById('homeownerForm').addEventListener('submit', e => { e.preventDefault(); nextScreen(); });
+  document.getElementById('homeownerForm').addEventListener('submit', e => {
+    e.preventDefault();
+    const f = e.currentTarget;
+    if (f.reportValidity()) nextScreen();
+  });
   document.getElementById('qualificationForm').addEventListener('submit', e => {
     e.preventDefault();
-    if (usage3) {
-      const v = Number(usage3.value);
-      setUsageKWh(Number.isFinite(v) && v > 0 ? v : null);
-    }
+    const f = e.currentTarget;
+    if (!f.reportValidity()) return;
+    const v = Number(document.getElementById('annualUsageKWh').value);
+    setUsageKWh(Number.isFinite(v) && v > 0 ? v : null);
     nextScreen();
   });
   document.getElementById('upgradesForm').addEventListener('submit', e => { e.preventDefault(); nextScreen(); });

--- a/qualifier.html
+++ b/qualifier.html
@@ -85,7 +85,7 @@
                             <input type="text" id="homeownerName1" required class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
                         </div>
                         <div>
-                            <label for="homeownerName2" class="block text-sm font-medium text-gray-700 mb-2">Homeowner 2 Name</label>
+                            <label for="homeownerName2" class="block text-sm font-medium text-gray-700 mb-2">Homeowner 2 Name (optional)</label>
                             <input type="text" id="homeownerName2" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
                         </div>
                     </div>
@@ -128,6 +128,9 @@
                         <div id="check3" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                         <div id="check4" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                         <div id="check5" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
+                        <div id="check6" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
+                        <div id="check7" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
+                        <div id="check8" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                     </div>
                 </div>
 
@@ -137,7 +140,7 @@
                         <legend id="homeowner-label" class="block text-lg font-medium text-gray-700 mb-3">Are you a homeowner?</legend>
                         <div class="flex space-x-4" role="radiogroup" aria-labelledby="homeowner-label">
                             <div class="flex items-center">
-                                <input type="radio" id="homeownerYes" name="homeowner" value="yes">
+                                <input type="radio" id="homeownerYes" name="homeowner" value="yes" required>
                                 <label for="homeownerYes" class="ml-2">Yes</label>
                             </div>
                             <div class="flex items-center">
@@ -156,7 +159,7 @@
                         <div id="tax-tooltip" class="tooltip bg-gray-800 text-white p-3 rounded-lg mb-3 text-sm" role="tooltip">The net metering program requires taxable income to qualify for certain credits.</div>
                         <div class="flex space-x-4" role="radiogroup" aria-labelledby="taxes-label">
                             <div class="flex items-center">
-                                <input type="radio" id="taxesYes" name="taxes" value="yes">
+                                <input type="radio" id="taxesYes" name="taxes" value="yes" required>
                                 <label for="taxesYes" class="ml-2">Yes</label>
                             </div>
                             <div class="flex items-center">
@@ -175,7 +178,7 @@
                         <div id="credit-tooltip" class="tooltip bg-gray-800 text-white p-3 rounded-lg mb-3 text-sm" role="tooltip">We do a soft check only to see if you're eligible for zero-down options.</div>
                         <div class="flex space-x-4" role="radiogroup" aria-labelledby="credit-label">
                             <div class="flex items-center">
-                                <input type="radio" id="creditYes" name="credit" value="yes">
+                                <input type="radio" id="creditYes" name="credit" value="yes" required>
                                 <label for="creditYes" class="ml-2">Yes</label>
                             </div>
                             <div class="flex items-center">
@@ -192,21 +195,21 @@
                             <button type="button" class="ml-2 w-5 h-5 bg-brandOrange text-white rounded-full text-xs flex items-center justify-center tooltip-btn" data-target="roof-tooltip" aria-label="More info about roof type">?</button>
                         </legend>
                         <div id="roof-tooltip" class="tooltip bg-gray-800 text-white p-3 rounded-lg mb-3 text-sm" role="tooltip">
-                            <p class="mb-2">This helps us determine which mounting brackets to use.</p>
-                            <div class="flex space-x-4">
-                                <div class="text-center">
-                                    <div class="w-16 h-12 bg-gray-600 mb-1 rounded"></div>
-                                    <span class="text-xs">Slatted</span>
-                                </div>
-                                <div class="text-center">
-                                    <div class="w-16 h-12 bg-brandOrange mb-1 rounded"></div>
-                                    <span class="text-xs">Panelled</span>
-                                </div>
+                            This helps us determine which mounting brackets to use.
+                        </div>
+                        <div class="flex space-x-4 mb-4">
+                            <div class="text-left">
+                                <img src="assets/qualify_assets/slatted.jpg" alt="Slatted roof" class="w-24 h-16 object-cover rounded mb-1" />
+                                <span class="text-xs">Slatted</span>
+                            </div>
+                            <div class="text-left">
+                                <img src="assets/qualify_assets/panelled.jpg" alt="Panelled roof" class="w-24 h-16 object-cover rounded mb-1" />
+                                <span class="text-xs">Panelled</span>
                             </div>
                         </div>
                         <div class="flex space-x-4" role="radiogroup" aria-labelledby="roof-label">
                             <div class="flex items-center">
-                                <input type="radio" id="roofSlatted" name="roof" value="slatted">
+                                <input type="radio" id="roofSlatted" name="roof" value="slatted" required>
                                 <label for="roofSlatted" class="ml-2">Slatted</label>
                             </div>
                             <div class="flex items-center">
@@ -217,24 +220,69 @@
                     </fieldset>
 
                     <!-- Question 5 -->
-                    <fieldset class="qualification-question" id="bill-fieldset">
-                        <legend id="bill-label" class="block text-lg font-medium text-gray-700 mb-3">Is your name on your electric bill?</legend>
-                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="bill-label">
+                    <fieldset class="qualification-question" id="statement-fieldset">
+                        <legend id="statement-label" class="block text-lg font-medium text-gray-700 mb-3">Do you have your yearly statement?</legend>
+                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="statement-label">
                             <div class="flex items-center">
-                                <input type="radio" id="billYes" name="electric_bill" value="yes">
-                                <label for="billYes" class="ml-2">Yes</label>
+                                <input type="radio" id="statementYes" name="statement" value="yes" required>
+                                <label for="statementYes" class="ml-2">Yes</label>
                             </div>
                             <div class="flex items-center">
-                                <input type="radio" id="billNo" name="electric_bill" value="no">
-                                <label for="billNo" class="ml-2">No</label>
+                                <input type="radio" id="statementNo" name="statement" value="no">
+                                <label for="statementNo" class="ml-2">No</label>
                             </div>
                         </div>
                     </fieldset>
 
                     <div>
-                        <label for="annualUsageKWh" class="block text-sm font-medium text-gray-700 mb-2">Yearly Usage from your bill (kWh/year)</label>
-                        <input type="number" id="annualUsageKWh" min="100" step="1" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent" placeholder="e.g., 12000">
+                        <label for="annualUsageKWh" class="block text-sm font-medium text-gray-700 mb-2">Yearly Usage from your statement (kWh/year)</label>
+                        <input type="number" id="annualUsageKWh" min="100" step="1" required class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent" placeholder="e.g., 12000">
                     </div>
+
+                    <!-- Question 6 -->
+                    <fieldset class="qualification-question" id="decision-fieldset">
+                        <legend id="decision-label" class="block text-lg font-medium text-gray-700 mb-3">Are all decision makers present?</legend>
+                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="decision-label">
+                            <div class="flex items-center">
+                                <input type="radio" id="decisionYes" name="decision" value="yes" required>
+                                <label for="decisionYes" class="ml-2">Yes</label>
+                            </div>
+                            <div class="flex items-center">
+                                <input type="radio" id="decisionNo" name="decision" value="no">
+                                <label for="decisionNo" class="ml-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <!-- Question 7 -->
+                    <fieldset class="qualification-question" id="newroof-fieldset">
+                        <legend id="newroof-label" class="block text-lg font-medium text-gray-700 mb-3">Do you need a new roof?</legend>
+                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="newroof-label">
+                            <div class="flex items-center">
+                                <input type="radio" id="newroofYes" name="newroof" value="yes" required>
+                                <label for="newroofYes" class="ml-2">Yes</label>
+                            </div>
+                            <div class="flex items-center">
+                                <input type="radio" id="newroofNo" name="newroof" value="no">
+                                <label for="newroofNo" class="ml-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <!-- Question 8 -->
+                    <fieldset class="qualification-question" id="tree-fieldset">
+                        <legend id="tree-label" class="block text-lg font-medium text-gray-700 mb-3">Do you need tree removal?</legend>
+                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="tree-label">
+                            <div class="flex items-center">
+                                <input type="radio" id="treeYes" name="tree_removal" value="yes" required>
+                                <label for="treeYes" class="ml-2">Yes</label>
+                            </div>
+                            <div class="flex items-center">
+                                <input type="radio" id="treeNo" name="tree_removal" value="no">
+                                <label for="treeNo" class="ml-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
 
                     <div class="flex justify-between pt-6">
                         <button type="button" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors back-btn">Back</button>
@@ -340,13 +388,6 @@
                 <p class="text-xs text-gray-500 mt-1">We’ll start the solar line that month.</p>
               </div>
 
-              <div class="mt-2 flex items-center space-x-3">
-                <input id="solarEscalator" type="checkbox" class="h-4 w-4 rounded border-gray-300">
-                <label for="solarEscalator" class="text-sm text-gray-700">
-                  Use a small solar escalator (2%/yr). Leave unchecked to show a flat solar payment.
-                </label>
-              </div>
-
               <div class="flex justify-between pt-4">
                 <button type="button" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors back-btn">
                   Back
@@ -379,9 +420,6 @@
                   <canvas id="savingsChart"></canvas>
                 </div>
                 <p id="savingsNote" class="text-center mt-4 text-lg font-semibold text-brandGreen"></p>
-                <p class="text-center mt-1 text-sm text-gray-500 italic">
-                  “Assuming Duke <em>never raises rates again</em>” shown as the flat series.
-                </p>
               </div>
 
               <div class="flex justify-between pt-6">


### PR DESCRIPTION
## Summary
- Left-align slatted and panelled roof photos in the qualification step
- Require completion of homeowner and qualification forms using built-in HTML validation
- Derive monthly bill from yearly usage and lock the field on the savings step
- Make second homeowner name optional
- Remove solar escalator toggle and “never raises rates again” messaging; keep 20-year cost chart flat and complete

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689baebdfccc832b9ea36c5adc34fe8c