### PR TITLE
Add roof images and reorder qualification questions

### DIFF
--- a/qualifier.html
+++ b/qualifier.html
@@ -85,7 +85,7 @@
                             <input type="text" id="homeownerName1" required class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
                         </div>
                         <div>
-                            <label for="homeownerName2" class="block text-sm font-medium text-gray-700 mb-2">Homeowner 2 Name</label>
+                            <label for="homeownerName2" class="block text-sm font-medium text-gray-700 mb-2">Homeowner 2 Name (optional)</label>
                             <input type="text" id="homeownerName2" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent">
                         </div>
                     </div>
@@ -128,6 +128,9 @@
                         <div id="check3" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                         <div id="check4" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                         <div id="check5" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
+                        <div id="check6" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
+                        <div id="check7" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
+                        <div id="check8" class="w-4 h-4 rounded-full bg-gray-300 transition-colors"></div>
                     </div>
                 </div>
 
@@ -137,7 +140,7 @@
                         <legend id="homeowner-label" class="block text-lg font-medium text-gray-700 mb-3">Are you a homeowner?</legend>
                         <div class="flex space-x-4" role="radiogroup" aria-labelledby="homeowner-label">
                             <div class="flex items-center">
-                                <input type="radio" id="homeownerYes" name="homeowner" value="yes">
+                                <input type="radio" id="homeownerYes" name="homeowner" value="yes" required>
                                 <label for="homeownerYes" class="ml-2">Yes</label>
                             </div>
                             <div class="flex items-center">
@@ -156,7 +159,7 @@
                         <div id="tax-tooltip" class="tooltip bg-gray-800 text-white p-3 rounded-lg mb-3 text-sm" role="tooltip">The net metering program requires taxable income to qualify for certain credits.</div>
                         <div class="flex space-x-4" role="radiogroup" aria-labelledby="taxes-label">
                             <div class="flex items-center">
-                                <input type="radio" id="taxesYes" name="taxes" value="yes">
+                                <input type="radio" id="taxesYes" name="taxes" value="yes" required>
                                 <label for="taxesYes" class="ml-2">Yes</label>
                             </div>
                             <div class="flex items-center">
@@ -175,7 +178,7 @@
                         <div id="credit-tooltip" class="tooltip bg-gray-800 text-white p-3 rounded-lg mb-3 text-sm" role="tooltip">We do a soft check only to see if you're eligible for zero-down options.</div>
                         <div class="flex space-x-4" role="radiogroup" aria-labelledby="credit-label">
                             <div class="flex items-center">
-                                <input type="radio" id="creditYes" name="credit" value="yes">
+                                <input type="radio" id="creditYes" name="credit" value="yes" required>
                                 <label for="creditYes" class="ml-2">Yes</label>
                             </div>
                             <div class="flex items-center">
@@ -192,21 +195,21 @@
                             <button type="button" class="ml-2 w-5 h-5 bg-brandOrange text-white rounded-full text-xs flex items-center justify-center tooltip-btn" data-target="roof-tooltip" aria-label="More info about roof type">?</button>
                         </legend>
                         <div id="roof-tooltip" class="tooltip bg-gray-800 text-white p-3 rounded-lg mb-3 text-sm" role="tooltip">
-                            <p class="mb-2">This helps us determine which mounting brackets to use.</p>
-                            <div class="flex space-x-4">
-                                <div class="text-center">
-                                    <div class="w-16 h-12 bg-gray-600 mb-1 rounded"></div>
-                                    <span class="text-xs">Slatted</span>
-                                </div>
-                                <div class="text-center">
-                                    <div class="w-16 h-12 bg-brandOrange mb-1 rounded"></div>
-                                    <span class="text-xs">Panelled</span>
-                                </div>
+                            This helps us determine which mounting brackets to use.
+                        </div>
+                        <div class="flex space-x-4 mb-4">
+                            <div class="text-left">
+                                <img src="assets/qualify_assets/slatted.jpg" alt="Slatted roof" class="w-24 h-16 object-cover rounded mb-1" />
+                                <span class="text-xs">Slatted</span>
+                            </div>
+                            <div class="text-left">
+                                <img src="assets/qualify_assets/panelled.jpg" alt="Panelled roof" class="w-24 h-16 object-cover rounded mb-1" />
+                                <span class="text-xs">Panelled</span>
                             </div>
                         </div>
                         <div class="flex space-x-4" role="radiogroup" aria-labelledby="roof-label">
                             <div class="flex items-center">
-                                <input type="radio" id="roofSlatted" name="roof" value="slatted">
+                                <input type="radio" id="roofSlatted" name="roof" value="slatted" required>
                                 <label for="roofSlatted" class="ml-2">Slatted</label>
                             </div>
                             <div class="flex items-center">
@@ -217,24 +220,69 @@
                     </fieldset>
 
                     <!-- Question 5 -->
-                    <fieldset class="qualification-question" id="bill-fieldset">
-                        <legend id="bill-label" class="block text-lg font-medium text-gray-700 mb-3">Is your name on your electric bill?</legend>
-                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="bill-label">
+                    <fieldset class="qualification-question" id="statement-fieldset">
+                        <legend id="statement-label" class="block text-lg font-medium text-gray-700 mb-3">Do you have your yearly statement?</legend>
+                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="statement-label">
                             <div class="flex items-center">
-                                <input type="radio" id="billYes" name="electric_bill" value="yes">
-                                <label for="billYes" class="ml-2">Yes</label>
+                                <input type="radio" id="statementYes" name="statement" value="yes" required>
+                                <label for="statementYes" class="ml-2">Yes</label>
                             </div>
                             <div class="flex items-center">
-                                <input type="radio" id="billNo" name="electric_bill" value="no">
-                                <label for="billNo" class="ml-2">No</label>
+                                <input type="radio" id="statementNo" name="statement" value="no">
+                                <label for="statementNo" class="ml-2">No</label>
                             </div>
                         </div>
                     </fieldset>
 
                     <div>
-                        <label for="annualUsageKWh" class="block text-sm font-medium text-gray-700 mb-2">Yearly Usage from your bill (kWh/year)</label>
-                        <input type="number" id="annualUsageKWh" min="100" step="1" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent" placeholder="e.g., 12000">
+                        <label for="annualUsageKWh" class="block text-sm font-medium text-gray-700 mb-2">Yearly Usage from your statement (kWh/year)</label>
+                        <input type="number" id="annualUsageKWh" min="100" step="1" required class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brandOrange focus:border-transparent" placeholder="e.g., 12000">
                     </div>
+
+                    <!-- Question 6 -->
+                    <fieldset class="qualification-question" id="decision-fieldset">
+                        <legend id="decision-label" class="block text-lg font-medium text-gray-700 mb-3">Are all decision makers present?</legend>
+                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="decision-label">
+                            <div class="flex items-center">
+                                <input type="radio" id="decisionYes" name="decision" value="yes" required>
+                                <label for="decisionYes" class="ml-2">Yes</label>
+                            </div>
+                            <div class="flex items-center">
+                                <input type="radio" id="decisionNo" name="decision" value="no">
+                                <label for="decisionNo" class="ml-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <!-- Question 7 -->
+                    <fieldset class="qualification-question" id="newroof-fieldset">
+                        <legend id="newroof-label" class="block text-lg font-medium text-gray-700 mb-3">Do you need a new roof?</legend>
+                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="newroof-label">
+                            <div class="flex items-center">
+                                <input type="radio" id="newroofYes" name="newroof" value="yes" required>
+                                <label for="newroofYes" class="ml-2">Yes</label>
+                            </div>
+                            <div class="flex items-center">
+                                <input type="radio" id="newroofNo" name="newroof" value="no">
+                                <label for="newroofNo" class="ml-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
+
+                    <!-- Question 8 -->
+                    <fieldset class="qualification-question" id="tree-fieldset">
+                        <legend id="tree-label" class="block text-lg font-medium text-gray-700 mb-3">Do you need tree removal?</legend>
+                        <div class="flex space-x-4" role="radiogroup" aria-labelledby="tree-label">
+                            <div class="flex items-center">
+                                <input type="radio" id="treeYes" name="tree_removal" value="yes" required>
+                                <label for="treeYes" class="ml-2">Yes</label>
+                            </div>
+                            <div class="flex items-center">
+                                <input type="radio" id="treeNo" name="tree_removal" value="no">
+                                <label for="treeNo" class="ml-2">No</label>
+                            </div>
+                        </div>
+                    </fieldset>
 
                     <div class="flex justify-between pt-6">
                         <button type="button" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors back-btn">Back</button>
@@ -340,13 +388,6 @@
                 <p class="text-xs text-gray-500 mt-1">We’ll start the solar line that month.</p>
               </div>
 
-              <div class="mt-2 flex items-center space-x-3">
-                <input id="solarEscalator" type="checkbox" class="h-4 w-4 rounded border-gray-300">
-                <label for="solarEscalator" class="text-sm text-gray-700">
-                  Use a small solar escalator (2%/yr). Leave unchecked to show a flat solar payment.
-                </label>
-              </div>
-
               <div class="flex justify-between pt-4">
                 <button type="button" class="bg-gray-300 hover:bg-gray-400 text-gray-700 font-bold py-3 px-6 rounded-lg transition-colors back-btn">
                   Back
@@ -379,9 +420,6 @@
                   <canvas id="savingsChart"></canvas>
                 </div>
                 <p id="savingsNote" class="text-center mt-4 text-lg font-semibold text-brandGreen"></p>
-                <p class="text-center mt-1 text-sm text-gray-500 italic">
-                  “Assuming Duke <em>never raises rates again</em>” shown as the flat series.
-                </p>
               </div>
 
               <div class="flex justify-between pt-6">


### PR DESCRIPTION
## Summary
- Left-align slatted and panelled roof photos in the qualification step
- Require completion of homeowner and qualification forms using built-in HTML validation
- Derive monthly bill from yearly usage and lock the field on the savings step
- Make second homeowner name optional
- Remove solar escalator toggle and “never raises rates again” messaging; keep 20-year cost chart flat and complete
- Fix savings step navigation so continue advances to scheduling and skip jumps straight to the final screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689baebdfccc832b9ea36c5adc34fe8c